### PR TITLE
Fixed autoreconf failed when README not found

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -1,2 +1,2 @@
 SUBDIRS = src
-
+AUTOMAKE_OPTIONS = foreign


### PR DESCRIPTION
When I tried to build Ckylark for the first time, it failed because the default sources of Ckylark did not include README, but README.md instead . 

I found the fixes in this link: 
http://stackoverflow.com/questions/15013672/use-autotools-with-readme-md
