### PR TITLE
Remove arguments of AM_INIT_AUTOMAKE which are deprecated

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3,7 +3,7 @@
 
 AC_PREREQ([2.69])
 AC_INIT([ckylark], [0.3.0], [yus.takara@gmail.com])
-AM_INIT_AUTOMAKE([ckylark], [0.3.0])
+AM_INIT_AUTOMAKE
 AC_CONFIG_SRCDIR([src/main.cc])
 AC_CONFIG_HEADERS([config.h])
 


### PR DESCRIPTION
See http://www.gnu.org/software/automake/manual/automake.html#Modernize-AM_005fINIT_005fAUTOMAKE-invocation
