### PR TITLE
Added BOOST_LDFLAGS to Makefile.am

### DIFF
--- a/src/bin/Makefile.am
+++ b/src/bin/Makefile.am
@@ -1,5 +1,5 @@
 AM_CXXFLAGS = -I$(srcdir)/../include $(BOOST_CPPFLAGS)
-LDADD = ../lib/libckylark.la $(BOOST_IOSTREAMS_LIBS) $(BOOST_PROGRAM_OPTIONS_LIB)
+LDADD = ../lib/libckylark.la $(BOOST_LDFLAGS) $(BOOST_IOSTREAMS_LIBS) $(BOOST_PROGRAM_OPTIONS_LIB)
 
 bin_PROGRAMS = ckylark
 

--- a/src/lib/Makefile.am
+++ b/src/lib/Makefile.am
@@ -28,5 +28,5 @@ libckylark_la_SOURCES = \
 	Timer.cc \
 	Tracer.cc
 
-libckylark_la_LDFLAGS = -version-info 0:4:0 $(BOOST_IOSTREAMS_LIB)
+libckylark_la_LDFLAGS = -version-info 0:4:0 $(BOOST_LDFLAGS) $(BOOST_IOSTREAMS_LIB)
 


### PR DESCRIPTION
Ckylark does not currently compile on Mac OSX, because Boost is installed to a directory that is not in the default path. By adding BOOST_LDFLAGS, this problem is fixed and compiling works.